### PR TITLE
Update runtime to 5.15-21.08

### DIFF
--- a/org.cubocore.CoreAction.yml
+++ b/org.cubocore.CoreAction.yml
@@ -1,6 +1,6 @@
 app-id: org.cubocore.CoreAction
 runtime: org.kde.Platform
-runtime-version: '5.15'
+runtime-version: '5.15-21.08'
 sdk: org.kde.Sdk
 command: coreaction
 finish-args:


### PR DESCRIPTION
The 5.15 version of the KDE Runtime is based on the 20.08 version of the Freedesktop Runtime and will stay as-is to keep compatibility.
The 5.15-21.08 version of the KDE Runtime is based on the 21.08 Freedesktop one. The Qt/KDE Libraries are mostyl similar between the two runtimes.

This change is mostly maintenance to keep the base runtime updated.