### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/org.cubocore.CoreAction.yml
+++ b/org.cubocore.CoreAction.yml
@@ -13,8 +13,7 @@ finish-args:
   - --filesystem=xdg-config:create # flatpak linter causes error on xdg-config
   - --system-talk-name=org.freedesktop.UPower # For battery plugin showing battery info
   - --talk-name=org.kde.StatusNotifierWatcher # For showing in the system tray
-  - --talk-name=org.freedesktop.Notifications 
-  - --own-name=org.kde.* # For showing in the system tray
+  - --talk-name=org.freedesktop.Notifications
 cleanup:
   - /include
   - /lib/cmake

--- a/org.cubocore.CoreAction.yml
+++ b/org.cubocore.CoreAction.yml
@@ -10,7 +10,7 @@ finish-args:
   - --socket=wayland
   - --device=dri
   - --filesystem=host:ro # Get plugins from host system if found
-  - --filesystem=xdg-config:create # flatpak linter causes error on xdg-config
+  - --filesystem=home
   - --system-talk-name=org.freedesktop.UPower # For battery plugin showing battery info
   - --talk-name=org.kde.StatusNotifierWatcher # For showing in the system tray
   - --talk-name=org.freedesktop.Notifications


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/ 66#issuecomment-1386033025